### PR TITLE
feat: added js solution (and tests) for challenge palindrome-number

### DIFF
--- a/challenges/easy/palindrome-number/solutions/aleattene/solution.js
+++ b/challenges/easy/palindrome-number/solutions/aleattene/solution.js
@@ -1,0 +1,32 @@
+/*
+JS solution for challenge: "Palindrome Number"
+To test the solution, type from CLI: npm test (required node.js and jest framework)
+*/
+
+
+function isPalindrome(number) {
+    // From number to String
+    let word = number.toString()
+
+    // Shift indexes (left and right)
+    let i = 0;
+    let j = word.length - 1;
+
+    // Returns false as soon as two different values are found
+    while (i <= j) {
+         if (word[i] !== word[j]) {
+             // The number is not palindrome
+             return false;
+         }
+         i++; j--;
+    }
+    // The number is palindrome
+    return true;
+}
+
+
+
+// Exports for the tests
+module.exports = {
+    isPalindrome,
+}

--- a/challenges/easy/palindrome-number/solutions/aleattene/solution.js
+++ b/challenges/easy/palindrome-number/solutions/aleattene/solution.js
@@ -5,13 +5,11 @@ To test the solution, type from CLI: npm test (required node.js and jest framewo
 
 
 function isPalindrome(number) {
-    // From number to String
+    // From number to string
     let word = number.toString()
-
     // Shift indexes (left and right)
     let i = 0;
     let j = word.length - 1;
-
     // Returns false as soon as two different values are found
     while (i <= j) {
          if (word[i] !== word[j]) {

--- a/challenges/easy/palindrome-number/solutions/aleattene/test.js
+++ b/challenges/easy/palindrome-number/solutions/aleattene/test.js
@@ -1,0 +1,18 @@
+/*
+To start the tests, type from CLI: npm test (required node.js and jest framework)
+*/
+
+// Import Functions
+const {isPalindrome} = require("./solution.js");
+
+// Tests for isPalindrome Function
+test('Palindrome Number - Unit Tests', () => {
+    expect(isPalindrome(121)).toBe(true);
+    expect(isPalindrome(-121)).toBe(false);
+    expect(isPalindrome(10)).toBe(false);
+    expect(isPalindrome(-101)).toBe(false);
+    expect(isPalindrome(12321)).toBe(true);
+    expect(isPalindrome(123456)).toBe(false);
+    expect(isPalindrome(0)).toBe(true);
+    expect(isPalindrome(1111111111111111)).toBe(true);
+});


### PR DESCRIPTION
Reviewers:
@micheleriva
@storrisi

I'm not sure it's the best solution.

An alternative but the **less performing** solution is for example this:
```
function isPalindrome(number) {
    let word = number.toString()
    let wordReversed = word.split("").reverse().join("")
    return (word === wordReversed)
}
```

Is possible to test the performance of both the solutions here:
[https://replit.com/join/tvletostle-aleattene](URL)

Any other advice is always welcome.